### PR TITLE
Use environment names compliant with IEEE Std 1003.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ When done, you will have something like this:
 
 ### Using
 
-    $ awsenv-ls                 # list all profiles.
-    $ awsenv-set account1       # activate 'account1' as PROFILE_NAME, if it exists.
+    $ awsenv_ls                 # list all profiles.
+    $ awsenv_set account1       # activate 'account1' as PROFILE_NAME, if it exists.
 
 
 

--- a/awsenv.sh
+++ b/awsenv.sh
@@ -38,7 +38,7 @@ function __awsenv_ps1() {
 ### Routines
 ###
 
-function awsenv-ls() {
+function awsenv_ls() {
 
     echo
     echo "AWSEnv: Profiles"
@@ -48,7 +48,7 @@ function awsenv-ls() {
 
 }
 
-function awsenv-set() {
+function awsenv_set() {
 
     profile="$1"
     if [ ! -d "${profiles_dir}/${profile}" ]

--- a/template-examples/README.md
+++ b/template-examples/README.md
@@ -28,11 +28,11 @@ used.
 Inside a *__template__* dir, defined by the variable *__awsenv_template_dir__*
 you can copy each config file to it and edit for your credentials.
 
-After that, you call *__awsenv-generate__* for each account you want:
+After that, you call *__awsenv_generate__* for each account you want:
 
 
-    awsenv-generate  account1
-    awsenv-generate  account2
+    awsenv_generate  account1
+    awsenv_generate  account2
 
 
 #### Examples:

--- a/template-examples/awsenv-generate.sh
+++ b/template-examples/awsenv-generate.sh
@@ -5,14 +5,14 @@
 ###
 
 
-function awsenv-generate() {
+function awsenv_generate() {
 
     profile="$1"
 
     if [ -z "${profile}" ]
     then
         echo
-        echo "Usage: awsenv-generate profile"
+        echo "Usage: awsenv_generate profile"
         echo
         return
     fi


### PR DESCRIPTION
Functions `awsenv-*` is not a valid identifier in IEEE Std 1003.1. This PR fixes this.

``` markdown
Environment variables defined in this chapter affect the operation of multiple utilities, functions, and applications.
There are other environment variables that are of interest only to specific utilities.
```

See [Open Group Base Specifications - Environment Variables](http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html) for more details.

WDYT?
